### PR TITLE
Add npm dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add a [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) config for `npm`, checking monthly

(You'll also need to ensure the option is enabled in the [security analysis settings](https://github.com/digital-overdose/digital-overdose.github.io/settings/security_analysis))